### PR TITLE
Add Stripe payments, Cloudinary photos, admin panel, notifications

### DIFF
--- a/api/checkout.js
+++ b/api/checkout.js
@@ -23,12 +23,15 @@ const ACTIVE_PRICES = {
 
 // Map all URL slugs to DB-safe tier values
 const TIER_CONFIG = {
-  victorypath: { amount: 2900, name: 'VictoryPath Membership', dbTier: 'individual', priceKey: 'individual' },
-  individual:  { amount: 2900, name: 'VictoryPath Membership', dbTier: 'individual', priceKey: 'individual' },
-  builder:     { amount: 4700, name: 'Value Builder',          dbTier: 'couple',     priceKey: 'couple' },
-  couple:      { amount: 4700, name: 'Value Builder',          dbTier: 'couple',     priceKey: 'couple' },
-  vip:         { amount: 49700, name: 'Victory VIP',           dbTier: 'premium',    priceKey: 'premium' },
-  premium:     { amount: 49700, name: 'Victory VIP',           dbTier: 'premium',    priceKey: 'premium' }
+  victorypath: { amount: 2900, name: 'VictoryPath Membership', dbTier: 'individual', priceKey: 'individual', mode: 'subscription' },
+  individual:  { amount: 2900, name: 'VictoryPath Membership', dbTier: 'individual', priceKey: 'individual', mode: 'subscription' },
+  builder:     { amount: 4700, name: 'Value Builder',          dbTier: 'couple',     priceKey: 'couple',     mode: 'subscription' },
+  couple:      { amount: 4700, name: 'Value Builder',          dbTier: 'couple',     priceKey: 'couple',     mode: 'subscription' },
+  vip:         { amount: 49700, name: 'Victory VIP',           dbTier: 'premium',    priceKey: 'premium',    mode: 'subscription' },
+  premium:     { amount: 49700, name: 'Victory VIP',           dbTier: 'premium',    priceKey: 'premium',    mode: 'subscription' },
+  // Dating-specific tiers
+  'dating-gate':  { amount: 97,    name: 'Aligned Hearts Assessment Fee', dbTier: 'individual', mode: 'payment', isDating: true },
+  'dating-monthly': { amount: 2900, name: 'Aligned Hearts Monthly',       dbTier: 'individual', priceKey: 'individual', mode: 'subscription', isDating: true }
 };
 
 const BASE_URL = 'https://assessment.valuetovictory.com';
@@ -158,8 +161,16 @@ module.exports = async (req, res) => {
 
             // Sync dating profile payment status
             try {
-              await sql`UPDATE dating_profiles SET is_paid = true, stripe_subscription_id = ${subscriptionId} WHERE contact_id = ${contactId}`;
+              await sql`UPDATE dating_profiles SET is_paid = true, stripe_subscription_id = ${subscriptionId || null} WHERE contact_id = ${contactId}`;
             } catch(e) { /* dating_profiles may not exist yet — that's OK */ }
+
+            // If this was a dating one-time gate payment ($0.97), restore trial
+            if (session.metadata?.payment_type === 'one_time' && session.metadata?.dating === 'true') {
+              try {
+                await sql`UPDATE dating_profiles SET trial_start = now(), trial_ends = now() + interval '30 days', is_paid = false WHERE contact_id = ${contactId}`;
+                console.log('[checkout] Dating trial restored for:', email);
+              } catch(e) { /* non-fatal */ }
+            }
           }
         }
       }
@@ -288,18 +299,46 @@ module.exports = async (req, res) => {
         }
       }
 
-      // Use hardcoded active prices directly -- env vars were stale/inactive
-      const priceId = ACTIVE_PRICES[config.priceKey];
-      console.log(`[Checkout] Using price ${priceId} for ${config.name} (${config.dbTier})`);
+      const isOneTime = config.mode === 'payment';
+      const isDating = config.isDating || false;
+      const successUrl = isDating
+        ? `${BASE_URL}/faith-match?payment=success&tier=${config.dbTier}`
+        : `${BASE_URL}/member?welcome=true&tier=${config.dbTier}`;
+      const cancelUrl = isDating ? `${BASE_URL}/faith-match` : `${BASE_URL}/pricing`;
 
-      const sessionParams = {
-        mode: 'subscription',
-        line_items: [{ price: priceId, quantity: 1 }],
-        success_url: `${BASE_URL}/member?welcome=true&tier=${config.dbTier}`,
-        cancel_url: `${BASE_URL}/pricing`,
-        metadata: { tier: config.dbTier },
-        allow_promotion_codes: true
-      };
+      let sessionParams;
+
+      if (isOneTime) {
+        // One-time payment (e.g., $0.97 dating assessment gate)
+        console.log(`[Checkout] Creating one-time payment: ${config.name} ($${(config.amount / 100).toFixed(2)})`);
+        sessionParams = {
+          mode: 'payment',
+          line_items: [{
+            price_data: {
+              currency: 'usd',
+              product_data: { name: config.name },
+              unit_amount: config.amount
+            },
+            quantity: 1
+          }],
+          success_url: successUrl,
+          cancel_url: cancelUrl,
+          metadata: { tier: config.dbTier, dating: isDating ? 'true' : 'false', payment_type: 'one_time' },
+          allow_promotion_codes: true
+        };
+      } else {
+        // Subscription (recurring)
+        const priceId = ACTIVE_PRICES[config.priceKey];
+        console.log(`[Checkout] Using price ${priceId} for ${config.name} (${config.dbTier})`);
+        sessionParams = {
+          mode: 'subscription',
+          line_items: [{ price: priceId, quantity: 1 }],
+          success_url: successUrl,
+          cancel_url: cancelUrl,
+          metadata: { tier: config.dbTier, dating: isDating ? 'true' : 'false' },
+          allow_promotion_codes: true
+        };
+      }
 
       if (email) {
         // Find existing Stripe customer to prevent duplicates

--- a/api/dating.js
+++ b/api/dating.js
@@ -741,6 +741,33 @@ module.exports = async (req, res) => {
       return res.json({ messages, myProfileId: myProfile[0].id });
     }
 
+    // ===== UNREAD COUNTS (for notification badges) =====
+    if (path === 'unread' && req.method === 'GET') {
+      const myProfile = await sql`SELECT id FROM dating_profiles WHERE contact_id = ${user.contactId}`;
+      if (!myProfile.length) return res.json({ unreadMessages: 0, newMatches: 0 });
+      const myId = myProfile[0].id;
+
+      // Unread messages: messages in my matches that I haven't read and I didn't send
+      const [unreadMsg] = await sql`
+        SELECT COUNT(*) as cnt FROM dating_messages m
+        JOIN dating_matches dm ON dm.id = m.match_id
+        WHERE (dm.profile_a_id = ${myId} OR dm.profile_b_id = ${myId})
+          AND dm.unmatched = false
+          AND m.sender_id != ${myId}
+          AND m.read_at IS NULL
+      `;
+
+      // New matches in last 24h
+      const [newMatches] = await sql`
+        SELECT COUNT(*) as cnt FROM dating_matches
+        WHERE (profile_a_id = ${myId} OR profile_b_id = ${myId})
+          AND unmatched = false
+          AND matched_at > now() - interval '24 hours'
+      `;
+
+      return res.json({ unreadMessages: +unreadMsg.cnt, newMatches: +newMatches.cnt });
+    }
+
     // ===== TOGGLE ACTIVE =====
     if (path === 'toggle-active' && req.method === 'POST') {
       const { active } = req.body;
@@ -764,7 +791,7 @@ module.exports = async (req, res) => {
       return res.json({ ok: true });
     }
 
-    // ===== UPLOAD PHOTO =====
+    // ===== UPLOAD PHOTO (Cloudinary CDN or base64 fallback) =====
     if (path === 'upload-photo' && req.method === 'POST') {
       const { photoBase64, photoIndex } = req.body;
       if (photoBase64 === undefined || photoIndex === undefined) {
@@ -781,8 +808,36 @@ module.exports = async (req, res) => {
 
       // Check size — base64 is ~33% larger than binary, so 2MB binary ~ 2.67MB base64
       const sizeBytes = Math.ceil((photoBase64.length - photoBase64.indexOf(',') - 1) * 0.75);
-      if (sizeBytes > 2 * 1024 * 1024) {
-        return res.status(400).json({ error: 'Photo must be under 2MB' });
+      if (sizeBytes > 5 * 1024 * 1024) {
+        return res.status(400).json({ error: 'Photo must be under 5MB' });
+      }
+
+      // Upload to Cloudinary CDN if configured, otherwise store base64
+      let photoUrl = photoBase64;
+      const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+      const uploadPreset = process.env.CLOUDINARY_UPLOAD_PRESET;
+
+      if (cloudName && uploadPreset) {
+        try {
+          const uploadRes = await fetch(`https://api.cloudinary.com/v1_1/${cloudName}/image/upload`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              file: photoBase64,
+              upload_preset: uploadPreset,
+              folder: `vtv-dating/${user.contactId}`,
+              transformation: 'c_limit,w_800,h_1000,q_auto,f_auto'
+            })
+          });
+          const uploadData = await uploadRes.json();
+          if (uploadData.secure_url) {
+            photoUrl = uploadData.secure_url;
+          } else {
+            console.warn('Cloudinary upload failed, falling back to base64:', uploadData.error?.message);
+          }
+        } catch (cloudErr) {
+          console.warn('Cloudinary upload error, falling back to base64:', cloudErr.message);
+        }
       }
 
       // Get current profile
@@ -792,11 +847,9 @@ module.exports = async (req, res) => {
       // Build photos array (up to 6 slots)
       let photos = profile[0].photo_urls || [];
       if (!Array.isArray(photos)) photos = [];
-      // Ensure array is at least photoIndex+1 long
       while (photos.length <= photoIndex) photos.push('');
-      // Cap at 6
       photos = photos.slice(0, 6);
-      photos[photoIndex] = photoBase64;
+      photos[photoIndex] = photoUrl;
 
       const photosJson = JSON.stringify(photos);
       await sql`
@@ -804,7 +857,7 @@ module.exports = async (req, res) => {
         WHERE contact_id = ${user.contactId}
       `;
 
-      return res.json({ ok: true, photos, message: 'Photo uploaded' });
+      return res.json({ ok: true, photos, photoUrl, cdn: photoUrl !== photoBase64, message: 'Photo uploaded' });
     }
 
     // ===== REMOVE PHOTO =====
@@ -830,6 +883,111 @@ module.exports = async (req, res) => {
       `;
 
       return res.json({ ok: true, photos, message: 'Photo removed' });
+    }
+
+    // =========================================================
+    // ADMIN MODERATION ENDPOINTS (require x-api-key header)
+    // =========================================================
+    const apiKey = req.headers['x-api-key'] || '';
+    const validKey = process.env.ADMIN_API_KEY || '';
+    const isAdmin = validKey && apiKey === validKey;
+
+    // ===== GET REPORTS (admin) =====
+    if (path === 'admin/reports' && req.method === 'GET' && isAdmin) {
+      const status = url.searchParams.get('status') || 'pending';
+      const reports = await sql`
+        SELECT dr.*,
+               rp.display_name as reporter_name, rp.photo_urls as reporter_photos,
+               dp.display_name as reported_name, dp.photo_urls as reported_photos,
+               dp.bio as reported_bio, dp.contact_id as reported_contact_id
+        FROM dating_reports dr
+        JOIN dating_profiles rp ON rp.id = dr.reporter_id
+        JOIN dating_profiles dp ON dp.id = dr.reported_id
+        WHERE dr.status = ${status}
+        ORDER BY dr.created_at DESC
+        LIMIT 50
+      `;
+      return res.json({ reports, count: reports.length });
+    }
+
+    // ===== UPDATE REPORT STATUS (admin) =====
+    if (path === 'admin/report-action' && req.method === 'POST' && isAdmin) {
+      const { report_id, action, reason } = req.body;
+      if (!report_id || !action) return res.status(400).json({ error: 'report_id and action required' });
+
+      if (action === 'dismiss') {
+        await sql`UPDATE dating_reports SET status = 'dismissed' WHERE id = ${report_id}`;
+        return res.json({ ok: true, action: 'dismissed' });
+      }
+
+      if (action === 'warn') {
+        await sql`UPDATE dating_reports SET status = 'warned' WHERE id = ${report_id}`;
+        return res.json({ ok: true, action: 'warned' });
+      }
+
+      if (action === 'suspend') {
+        const report = await sql`SELECT reported_id FROM dating_reports WHERE id = ${report_id}`;
+        if (report.length) {
+          await sql`UPDATE dating_profiles SET is_active = false WHERE id = ${report[0].reported_id}`;
+          await sql`UPDATE dating_reports SET status = 'suspended' WHERE id = ${report_id}`;
+        }
+        return res.json({ ok: true, action: 'suspended' });
+      }
+
+      if (action === 'ban') {
+        const report = await sql`SELECT reported_id FROM dating_reports WHERE id = ${report_id}`;
+        if (report.length) {
+          await sql`UPDATE dating_profiles SET is_active = false WHERE id = ${report[0].reported_id}`;
+          await sql`UPDATE dating_reports SET status = 'banned' WHERE id = ${report_id}`;
+          // Also add to blocks from all users who reported
+          const allReports = await sql`SELECT DISTINCT reporter_id FROM dating_reports WHERE reported_id = ${report[0].reported_id}`;
+          for (const r of allReports) {
+            await sql`INSERT INTO dating_blocks (blocker_id, blocked_id, reason) VALUES (${r.reporter_id}, ${report[0].reported_id}, ${reason || 'admin_ban'}) ON CONFLICT DO NOTHING`;
+          }
+        }
+        return res.json({ ok: true, action: 'banned' });
+      }
+
+      return res.status(400).json({ error: 'Invalid action. Use: dismiss, warn, suspend, ban' });
+    }
+
+    // ===== GET ALL DATING PROFILES (admin) =====
+    if (path === 'admin/profiles' && req.method === 'GET' && isAdmin) {
+      const profiles = await sql`
+        SELECT dp.*, c.email, c.first_name, c.last_name,
+               (SELECT COUNT(*) FROM dating_reports WHERE reported_id = dp.id AND status = 'pending') as pending_reports,
+               (SELECT COUNT(*) FROM dating_matches WHERE (profile_a_id = dp.id OR profile_b_id = dp.id) AND unmatched = false) as match_count,
+               (SELECT COUNT(*) FROM dating_swipes WHERE swiper_id = dp.id AND direction = 'right') as likes_given,
+               (SELECT COUNT(*) FROM dating_swipes WHERE swiped_id = dp.id AND direction = 'right') as likes_received
+        FROM dating_profiles dp
+        JOIN contacts c ON c.id = dp.contact_id
+        ORDER BY dp.created_at DESC
+        LIMIT 100
+      `;
+      return res.json({ profiles, count: profiles.length });
+    }
+
+    // ===== DATING STATS (admin) =====
+    if (path === 'admin/stats' && req.method === 'GET' && isAdmin) {
+      const [totalProfiles] = await sql`SELECT COUNT(*) as cnt FROM dating_profiles`;
+      const [activeProfiles] = await sql`SELECT COUNT(*) as cnt FROM dating_profiles WHERE is_active = true`;
+      const [totalMatches] = await sql`SELECT COUNT(*) as cnt FROM dating_matches WHERE unmatched = false`;
+      const [totalMessages] = await sql`SELECT COUNT(*) as cnt FROM dating_messages`;
+      const [pendingReports] = await sql`SELECT COUNT(*) as cnt FROM dating_reports WHERE status = 'pending'`;
+      const [paidUsers] = await sql`SELECT COUNT(*) as cnt FROM dating_profiles WHERE is_paid = true`;
+      const [trialUsers] = await sql`SELECT COUNT(*) as cnt FROM dating_profiles WHERE is_paid = false AND trial_ends > now()`;
+      const recentSignups = await sql`SELECT id, display_name, gender, created_at FROM dating_profiles ORDER BY created_at DESC LIMIT 10`;
+
+      return res.json({
+        totalProfiles: +totalProfiles.cnt,
+        activeProfiles: +activeProfiles.cnt,
+        totalMatches: +totalMatches.cnt,
+        totalMessages: +totalMessages.cnt,
+        pendingReports: +pendingReports.cnt,
+        paidUsers: +paidUsers.cnt,
+        trialUsers: +trialUsers.cnt,
+        recentSignups
+      });
     }
 
     return res.status(404).json({ error: 'Not found' });

--- a/dating-admin.html
+++ b/dating-admin.html
@@ -1,0 +1,530 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<link rel="icon" type="image/png" href="/favicon.png"/>
+<link href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900&display=swap" rel="stylesheet">
+<title>Aligned Hearts Admin — The Value Engine</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'Satoshi', sans-serif; background: #0a0a0a; color: #e4e4e7; min-height: 100vh; }
+
+  /* ── Login Screen ── */
+  .login-screen {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 100vh; padding: 1.5rem;
+  }
+  .login-box {
+    width: 100%; max-width: 380px; text-align: center;
+  }
+  .login-brand {
+    font-size: 0.65rem; letter-spacing: 0.25em; text-transform: uppercase;
+    color: #D4A847; font-weight: 700; margin-bottom: 0.35rem;
+  }
+  .login-title {
+    font-size: 1.4rem; font-weight: 700; color: #fff; margin-bottom: 2rem;
+  }
+  .login-box input {
+    width: 100%; padding: 0.85rem 1rem; background: #18181b;
+    border: 1px solid #27272a; border-radius: 0.5rem; color: #e4e4e7;
+    font-size: 0.95rem; font-family: inherit; outline: none; margin-bottom: 0.75rem;
+  }
+  .login-box input:focus { border-color: #D4A847; }
+  .login-box input::placeholder { color: #52525b; }
+  .login-btn {
+    width: 100%; padding: 0.85rem; background: linear-gradient(135deg, #D4A847, #b8942e);
+    color: #0a0a0a; font-size: 0.95rem; font-weight: 700; border: none;
+    border-radius: 0.5rem; cursor: pointer; font-family: inherit; transition: opacity 0.2s;
+  }
+  .login-btn:hover { opacity: 0.9; }
+  .login-error {
+    color: #ef4444; font-size: 0.8rem; margin-top: 0.75rem; display: none;
+  }
+
+  /* ── Dashboard Shell ── */
+  .dashboard { display: none; }
+  .dashboard.show { display: block; }
+
+  .topbar {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0.85rem 1.5rem; border-bottom: 1px solid #1a1a1a;
+  }
+  .topbar-left { display: flex; align-items: center; gap: 0.75rem; }
+  .topbar-brand {
+    font-size: 0.6rem; letter-spacing: 0.2em; text-transform: uppercase;
+    color: #D4A847; font-weight: 700;
+  }
+  .topbar-title { font-size: 1rem; font-weight: 700; color: #fff; }
+  .topbar-logout {
+    padding: 0.4rem 0.85rem; background: transparent; border: 1px solid #27272a;
+    border-radius: 0.375rem; color: #a1a1aa; font-size: 0.75rem; font-family: inherit;
+    cursor: pointer; transition: border-color 0.2s, color 0.2s;
+  }
+  .topbar-logout:hover { border-color: #ef4444; color: #ef4444; }
+
+  .main { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+
+  /* ── Stats Grid ── */
+  .stats-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 0.5rem; margin-bottom: 1.75rem;
+  }
+  .stat-card {
+    background: #18181b; border: 1px solid #27272a; border-radius: 0.625rem;
+    padding: 1rem; text-align: center;
+  }
+  .stat-value { font-size: 1.6rem; font-weight: 900; color: #D4A847; line-height: 1; }
+  .stat-label {
+    font-size: 0.6rem; color: #71717a; text-transform: uppercase;
+    letter-spacing: 0.08em; margin-top: 0.35rem; font-weight: 500;
+  }
+
+  /* ── Tabs ── */
+  .tabs {
+    display: flex; gap: 0; border-bottom: 1px solid #27272a; margin-bottom: 1.25rem;
+  }
+  .tab-btn {
+    padding: 0.65rem 1.25rem; background: none; border: none;
+    border-bottom: 2px solid transparent; color: #71717a; font-size: 0.85rem;
+    font-weight: 500; font-family: inherit; cursor: pointer; transition: all 0.2s;
+  }
+  .tab-btn:hover { color: #a1a1aa; }
+  .tab-btn.active { color: #D4A847; border-bottom-color: #D4A847; }
+
+  .tab-panel { display: none; }
+  .tab-panel.active { display: block; }
+
+  /* ── Reports ── */
+  .report-card {
+    background: #18181b; border: 1px solid #27272a; border-radius: 0.625rem;
+    padding: 1rem 1.25rem; margin-bottom: 0.5rem;
+  }
+  .report-header {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    gap: 1rem; flex-wrap: wrap;
+  }
+  .report-people { font-size: 0.85rem; color: #e4e4e7; }
+  .report-people strong { color: #fff; font-weight: 700; }
+  .report-people .arrow { color: #D4A847; margin: 0 0.35rem; }
+  .report-date { font-size: 0.7rem; color: #52525b; white-space: nowrap; }
+  .report-reason {
+    display: inline-block; margin-top: 0.5rem; padding: 0.2rem 0.55rem;
+    background: #27272a; border-radius: 0.25rem; font-size: 0.7rem;
+    color: #a1a1aa; font-weight: 500; text-transform: capitalize;
+  }
+  .report-details {
+    margin-top: 0.5rem; font-size: 0.8rem; color: #a1a1aa; line-height: 1.5;
+  }
+  .report-actions {
+    display: flex; gap: 0.4rem; margin-top: 0.75rem; flex-wrap: wrap;
+  }
+  .action-btn {
+    padding: 0.35rem 0.75rem; border: 1px solid #27272a; border-radius: 0.375rem;
+    font-size: 0.7rem; font-weight: 600; font-family: inherit; cursor: pointer;
+    transition: all 0.2s; background: transparent;
+  }
+  .action-btn:disabled { opacity: 0.4; cursor: default; }
+  .action-btn.dismiss { color: #a1a1aa; }
+  .action-btn.dismiss:hover:not(:disabled) { background: #27272a; color: #e4e4e7; }
+  .action-btn.warn { color: #eab308; border-color: rgba(234,179,8,0.3); }
+  .action-btn.warn:hover:not(:disabled) { background: rgba(234,179,8,0.1); }
+  .action-btn.suspend { color: #f97316; border-color: rgba(249,115,22,0.3); }
+  .action-btn.suspend:hover:not(:disabled) { background: rgba(249,115,22,0.1); }
+  .action-btn.ban { color: #ef4444; border-color: rgba(239,68,68,0.3); }
+  .action-btn.ban:hover:not(:disabled) { background: rgba(239,68,68,0.1); }
+
+  .empty-state {
+    text-align: center; padding: 3rem 1rem; color: #52525b; font-size: 0.85rem;
+  }
+
+  .report-resolved {
+    display: inline-block; padding: 0.2rem 0.6rem; border-radius: 0.25rem;
+    font-size: 0.7rem; font-weight: 600; margin-top: 0.75rem;
+  }
+  .resolved-dismiss { background: #27272a; color: #a1a1aa; }
+  .resolved-warn { background: rgba(234,179,8,0.15); color: #eab308; }
+  .resolved-suspend { background: rgba(249,115,22,0.15); color: #f97316; }
+  .resolved-ban { background: rgba(239,68,68,0.15); color: #ef4444; }
+
+  /* ── Profiles Table ── */
+  .table-wrap { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+  th {
+    text-align: left; color: #71717a; font-size: 0.6rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.06em; padding: 0.6rem 0.5rem;
+    border-bottom: 1px solid #27272a; white-space: nowrap;
+  }
+  td {
+    padding: 0.6rem 0.5rem; border-bottom: 1px solid #1f1f23; color: #e4e4e7;
+    white-space: nowrap;
+  }
+  tr:hover td { background: #1c1c1f; }
+  .badge {
+    display: inline-block; padding: 0.15rem 0.45rem; border-radius: 0.25rem;
+    font-size: 0.6rem; font-weight: 700; text-transform: uppercase;
+  }
+  .badge-green { background: #052e16; color: #22c55e; }
+  .badge-red { background: #3b1114; color: #ef4444; }
+  .badge-gold { background: #3b3006; color: #D4A847; }
+  .badge-gray { background: #27272a; color: #71717a; }
+
+  /* ── Loading / Error ── */
+  .spinner {
+    display: inline-block; width: 18px; height: 18px;
+    border: 2px solid #27272a; border-top-color: #D4A847;
+    border-radius: 50%; animation: spin 0.6s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .loading-row { text-align: center; padding: 2rem; color: #52525b; }
+  .error-msg {
+    padding: 0.75rem 1rem; background: #3b1114; border: 1px solid rgba(239,68,68,0.3);
+    border-radius: 0.5rem; color: #ef4444; font-size: 0.8rem; margin-bottom: 1rem;
+  }
+
+  /* ── Toast ── */
+  .toast-container {
+    position: fixed; bottom: 1.5rem; right: 1.5rem;
+    display: flex; flex-direction: column; gap: 0.5rem; z-index: 1000;
+  }
+  .toast {
+    padding: 0.65rem 1rem; border-radius: 0.5rem; font-size: 0.78rem;
+    font-weight: 500; animation: slideIn 0.3s ease; min-width: 220px;
+  }
+  .toast-success { background: #052e16; border: 1px solid rgba(34,197,94,0.3); color: #22c55e; }
+  .toast-error { background: #3b1114; border: 1px solid rgba(239,68,68,0.3); color: #ef4444; }
+  @keyframes slideIn { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+  /* ── Responsive ── */
+  @media (max-width: 640px) {
+    .stats-grid { grid-template-columns: repeat(2, 1fr); }
+    .topbar { flex-wrap: wrap; gap: 0.5rem; }
+    .main { padding: 1rem; }
+    .report-header { flex-direction: column; gap: 0.25rem; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ═══════════ LOGIN ═══════════ -->
+<div class="login-screen" id="loginScreen">
+  <div class="login-box">
+    <div class="login-brand">The Value Engine</div>
+    <div class="login-title">Aligned Hearts Admin</div>
+    <input type="password" id="apiKeyInput" placeholder="Admin API Key" autocomplete="off"/>
+    <button class="login-btn" id="loginBtn">Sign In</button>
+    <div class="login-error" id="loginError">Invalid API key. Please try again.</div>
+  </div>
+</div>
+
+<!-- ═══════════ DASHBOARD ═══════════ -->
+<div class="dashboard" id="dashboard">
+
+  <!-- Top bar -->
+  <div class="topbar">
+    <div class="topbar-left">
+      <div>
+        <div class="topbar-brand">The Value Engine</div>
+        <div class="topbar-title">Aligned Hearts Admin</div>
+      </div>
+    </div>
+    <button class="topbar-logout" id="logoutBtn">Log Out</button>
+  </div>
+
+  <div class="main">
+
+    <!-- Stats -->
+    <div class="stats-grid" id="statsGrid">
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Total Profiles</div></div>
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Active</div></div>
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Matches</div></div>
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Messages</div></div>
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Pending Reports</div></div>
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Paid Users</div></div>
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Trial Users</div></div>
+      <div class="stat-card"><div class="stat-value">--</div><div class="stat-label">Recent Signups</div></div>
+    </div>
+
+    <!-- Tabs -->
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="reports">Reports</button>
+      <button class="tab-btn" data-tab="profiles">Profiles</button>
+    </div>
+
+    <!-- Reports Panel -->
+    <div class="tab-panel active" id="panel-reports">
+      <div class="loading-row" id="reportsLoading"><span class="spinner"></span></div>
+      <div id="reportsError"></div>
+      <div id="reportsList"></div>
+    </div>
+
+    <!-- Profiles Panel -->
+    <div class="tab-panel" id="panel-profiles">
+      <div class="loading-row" id="profilesLoading"><span class="spinner"></span></div>
+      <div id="profilesError"></div>
+      <div class="table-wrap" id="profilesTableWrap" style="display:none;">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th><th>Email</th><th>Gender</th><th>Active</th>
+              <th>Paid</th><th>Reports</th><th>Matches</th>
+              <th>Likes Given</th><th>Likes Recv</th><th>Joined</th>
+            </tr>
+          </thead>
+          <tbody id="profilesBody"></tbody>
+        </table>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- Toast container -->
+<div class="toast-container" id="toasts"></div>
+
+<script>
+(function () {
+  // ── Elements ──
+  const loginScreen  = document.getElementById('loginScreen');
+  const dashboard    = document.getElementById('dashboard');
+  const apiKeyInput  = document.getElementById('apiKeyInput');
+  const loginBtn     = document.getElementById('loginBtn');
+  const loginError   = document.getElementById('loginError');
+  const logoutBtn    = document.getElementById('logoutBtn');
+  const statsGrid    = document.getElementById('statsGrid');
+  const reportsList  = document.getElementById('reportsList');
+  const reportsLoad  = document.getElementById('reportsLoading');
+  const reportsErr   = document.getElementById('reportsError');
+  const profilesBody = document.getElementById('profilesBody');
+  const profilesLoad = document.getElementById('profilesLoading');
+  const profilesErr  = document.getElementById('profilesError');
+  const profilesWrap = document.getElementById('profilesTableWrap');
+  const toasts       = document.getElementById('toasts');
+
+  const STORAGE_KEY = 'vtv_admin_key';
+
+  // ── Helpers ──
+  function getKey() { return localStorage.getItem(STORAGE_KEY) || ''; }
+
+  async function api(method, path, body) {
+    const opts = {
+      method,
+      headers: { 'x-api-key': getKey(), 'Content-Type': 'application/json' },
+    };
+    if (body) opts.body = JSON.stringify(body);
+    const res = await fetch(path, opts);
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(text || `HTTP ${res.status}`);
+    }
+    return res.json();
+  }
+
+  function toast(msg, type) {
+    const el = document.createElement('div');
+    el.className = 'toast toast-' + type;
+    el.textContent = msg;
+    toasts.appendChild(el);
+    setTimeout(() => { el.style.opacity = '0'; setTimeout(() => el.remove(), 300); }, 3000);
+  }
+
+  function fmtDate(d) {
+    if (!d) return '--';
+    const dt = new Date(d);
+    return dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  function fmtNum(n) {
+    if (n == null) return '--';
+    return Number(n).toLocaleString();
+  }
+
+  function esc(s) {
+    if (!s) return '';
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  // ── Auth ──
+  function showDashboard() {
+    loginScreen.style.display = 'none';
+    dashboard.classList.add('show');
+    loadStats();
+    loadReports();
+  }
+
+  function showLogin() {
+    dashboard.classList.remove('show');
+    loginScreen.style.display = 'flex';
+    apiKeyInput.value = '';
+    loginError.style.display = 'none';
+  }
+
+  // Check stored key on load
+  if (getKey()) {
+    showDashboard();
+  }
+
+  loginBtn.addEventListener('click', async () => {
+    const key = apiKeyInput.value.trim();
+    if (!key) { loginError.style.display = 'block'; return; }
+    localStorage.setItem(STORAGE_KEY, key);
+    // Validate by calling stats
+    try {
+      await api('GET', '/api/dating/admin/stats');
+      loginError.style.display = 'none';
+      showDashboard();
+    } catch (e) {
+      localStorage.removeItem(STORAGE_KEY);
+      loginError.style.display = 'block';
+    }
+  });
+
+  apiKeyInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') loginBtn.click();
+  });
+
+  logoutBtn.addEventListener('click', () => {
+    localStorage.removeItem(STORAGE_KEY);
+    showLogin();
+  });
+
+  // ── Tabs ──
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+      btn.classList.add('active');
+      const panel = document.getElementById('panel-' + btn.dataset.tab);
+      panel.classList.add('active');
+
+      // Lazy-load profiles on first visit
+      if (btn.dataset.tab === 'profiles' && !profilesBody.children.length) {
+        loadProfiles();
+      }
+    });
+  });
+
+  // ── Load Stats ──
+  async function loadStats() {
+    try {
+      const d = await api('GET', '/api/dating/admin/stats');
+      const fields = [
+        { key: 'totalProfiles',  label: 'Total Profiles' },
+        { key: 'activeProfiles', label: 'Active' },
+        { key: 'totalMatches',   label: 'Matches' },
+        { key: 'totalMessages',  label: 'Messages' },
+        { key: 'pendingReports', label: 'Pending Reports' },
+        { key: 'paidUsers',      label: 'Paid Users' },
+        { key: 'trialUsers',     label: 'Trial Users' },
+        { key: 'recentSignups',  label: 'Recent Signups' },
+      ];
+      statsGrid.innerHTML = fields.map(f => `
+        <div class="stat-card">
+          <div class="stat-value">${fmtNum(d[f.key])}</div>
+          <div class="stat-label">${f.label}</div>
+        </div>
+      `).join('');
+    } catch (e) {
+      console.error('Stats error:', e);
+    }
+  }
+
+  // ── Load Reports ──
+  async function loadReports() {
+    reportsLoad.style.display = 'block';
+    reportsErr.innerHTML = '';
+    reportsList.innerHTML = '';
+    try {
+      const data = await api('GET', '/api/dating/admin/reports?status=pending');
+      reportsLoad.style.display = 'none';
+      const reports = data.reports || data || [];
+      if (!reports.length) {
+        reportsList.innerHTML = '<div class="empty-state">No pending reports.</div>';
+        return;
+      }
+      reportsList.innerHTML = reports.map(r => `
+        <div class="report-card" id="report-${esc(r.id || r.report_id)}">
+          <div class="report-header">
+            <div class="report-people">
+              <strong>${esc(r.reporter_name || r.reporter)}</strong>
+              <span class="arrow">&#8594;</span>
+              <strong>${esc(r.reported_name || r.reported)}</strong>
+            </div>
+            <div class="report-date">${fmtDate(r.created_at || r.date)}</div>
+          </div>
+          <div class="report-reason">${esc(r.reason)}</div>
+          ${r.details ? '<div class="report-details">' + esc(r.details) + '</div>' : ''}
+          <div class="report-actions" data-report-id="${esc(r.id || r.report_id)}">
+            <button class="action-btn dismiss" onclick="handleAction(this,'dismiss')">Dismiss</button>
+            <button class="action-btn warn" onclick="handleAction(this,'warn')">Warn</button>
+            <button class="action-btn suspend" onclick="handleAction(this,'suspend')">Suspend</button>
+            <button class="action-btn ban" onclick="handleAction(this,'ban')">Ban</button>
+          </div>
+        </div>
+      `).join('');
+    } catch (e) {
+      reportsLoad.style.display = 'none';
+      reportsErr.innerHTML = '<div class="error-msg">Failed to load reports: ' + esc(e.message) + '</div>';
+    }
+  }
+
+  // ── Report Action (global for onclick) ──
+  window.handleAction = async function (btn, action) {
+    const container = btn.closest('.report-actions');
+    const reportId = container.dataset.reportId;
+    const buttons = container.querySelectorAll('.action-btn');
+    buttons.forEach(b => b.disabled = true);
+    try {
+      await api('POST', '/api/dating/admin/report-action', { report_id: reportId, action });
+      toast('Report ' + action + (action === 'dismiss' ? 'ed' : action === 'ban' ? 'ned' : 'ed') + ' successfully.', 'success');
+      // Replace actions with resolved badge
+      const labels = { dismiss: 'Dismissed', warn: 'Warned', suspend: 'Suspended', ban: 'Banned' };
+      container.innerHTML = '<span class="report-resolved resolved-' + action + '">' + labels[action] + '</span>';
+      // Refresh stats to update pending count
+      loadStats();
+    } catch (e) {
+      toast('Action failed: ' + e.message, 'error');
+      buttons.forEach(b => b.disabled = false);
+    }
+  };
+
+  // ── Load Profiles ──
+  async function loadProfiles() {
+    profilesLoad.style.display = 'block';
+    profilesErr.innerHTML = '';
+    profilesWrap.style.display = 'none';
+    try {
+      const data = await api('GET', '/api/dating/admin/profiles');
+      profilesLoad.style.display = 'none';
+      const profiles = data.profiles || data || [];
+      if (!profiles.length) {
+        profilesErr.innerHTML = '<div class="empty-state">No profiles found.</div>';
+        return;
+      }
+      profilesBody.innerHTML = profiles.map(p => `
+        <tr>
+          <td>${esc(p.display_name)}</td>
+          <td>${esc(p.email)}</td>
+          <td>${esc(p.gender || '--')}</td>
+          <td><span class="badge ${p.is_active ? 'badge-green' : 'badge-red'}">${p.is_active ? 'Yes' : 'No'}</span></td>
+          <td><span class="badge ${p.is_paid ? 'badge-gold' : 'badge-gray'}">${p.is_paid ? 'Paid' : 'Free'}</span></td>
+          <td>${p.pending_reports ? '<span class="badge badge-red">' + fmtNum(p.pending_reports) + '</span>' : '0'}</td>
+          <td>${fmtNum(p.match_count)}</td>
+          <td>${fmtNum(p.likes_given)}</td>
+          <td>${fmtNum(p.likes_received)}</td>
+          <td>${fmtDate(p.created_at)}</td>
+        </tr>
+      `).join('');
+      profilesWrap.style.display = 'block';
+    } catch (e) {
+      profilesLoad.style.display = 'none';
+      profilesErr.innerHTML = '<div class="error-msg">Failed to load profiles: ' + esc(e.message) + '</div>';
+    }
+  }
+
+})();
+</script>
+</body>
+</html>

--- a/faith-match.html
+++ b/faith-match.html
@@ -877,16 +877,17 @@ async function submitNewPin(email) {
 }
 
 function showTrialExpired(plan) {
+  const email = userEmail || localStorage.getItem('ve_email') || '';
   const loginBox = document.getElementById('login-screen').querySelector('.login-box');
   if (plan === 'locked_no_assessment') {
     loginBox.innerHTML += `
       <div style="margin-top:1rem;padding:1rem;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.3);border-radius:0.5rem;text-align:center;">
         <p style="color:var(--red);font-size:0.95rem;font-weight:700;">Access Locked</p>
         <p style="color:var(--muted);font-size:0.8rem;margin-top:0.5rem;">You didn't complete the P.I.N.K. assessment within 3 days.</p>
-        <p style="color:var(--muted);font-size:0.8rem;margin-top:0.25rem;">A <strong style="color:var(--text);">$0.97 charge</strong> has been applied.</p>
-        <p style="color:var(--muted);font-size:0.75rem;margin-top:0.5rem;">To restore access, either:</p>
-        <a href="/" style="display:inline-block;margin-top:0.5rem;padding:0.65rem 1.5rem;background:linear-gradient(135deg,var(--gold),var(--gold-dark));color:var(--bg);font-weight:700;border-radius:0.5rem;text-decoration:none;font-size:0.85rem;">Complete the Assessment (restores 30-day trial)</a>
-        <a href="/pricing" style="display:inline-block;margin-top:0.4rem;padding:0.55rem 1.5rem;background:transparent;border:1px solid var(--border);color:var(--text);font-weight:600;border-radius:0.5rem;text-decoration:none;font-size:0.8rem;">Subscribe $29/month</a>
+        <p style="color:var(--muted);font-size:0.75rem;margin-top:0.5rem;">To restore your 30-day trial:</p>
+        <a href="/checkout?tier=dating-gate&email=${encodeURIComponent(email)}" style="display:inline-block;margin-top:0.5rem;padding:0.65rem 1.5rem;background:linear-gradient(135deg,var(--gold),var(--gold-dark));color:var(--bg);font-weight:700;border-radius:0.5rem;text-decoration:none;font-size:0.85rem;">Pay $0.97 & Restore Trial</a>
+        <a href="/?email=${encodeURIComponent(email)}&mode=relationship&depth=quick&from=faith-match" style="display:inline-block;margin-top:0.4rem;padding:0.55rem 1.5rem;background:transparent;border:1px solid var(--green);color:var(--green);font-weight:600;border-radius:0.5rem;text-decoration:none;font-size:0.8rem;">Complete Assessment (Free)</a>
+        <a href="/checkout?tier=dating-monthly&email=${encodeURIComponent(email)}" style="display:inline-block;margin-top:0.4rem;padding:0.55rem 1.5rem;background:transparent;border:1px solid var(--border);color:var(--text);font-weight:600;border-radius:0.5rem;text-decoration:none;font-size:0.8rem;">Subscribe $29/month</a>
       </div>`;
   } else if (plan === 'monthly') {
     loginBox.innerHTML += `
@@ -894,8 +895,18 @@ function showTrialExpired(plan) {
         <p style="color:var(--gold);font-size:0.95rem;font-weight:700;">Your 30-Day Trial Has Ended</p>
         <p style="color:var(--muted);font-size:0.8rem;margin-top:0.5rem;">Subscribe for <strong style="color:var(--text);">$29/month</strong> to continue using Aligned Hearts</p>
         <p style="color:var(--green);font-size:0.75rem;margin-top:0.35rem;">Includes full VTV website & portal access</p>
-        <a href="/pricing" style="display:inline-block;margin-top:0.75rem;padding:0.65rem 1.5rem;background:linear-gradient(135deg,var(--gold),var(--gold-dark));color:var(--bg);font-weight:700;border-radius:0.5rem;text-decoration:none;font-size:0.9rem;">Subscribe Now</a>
+        <a href="/checkout?tier=dating-monthly&email=${encodeURIComponent(email)}" style="display:inline-block;margin-top:0.75rem;padding:0.65rem 1.5rem;background:linear-gradient(135deg,var(--gold),var(--gold-dark));color:var(--bg);font-weight:700;border-radius:0.5rem;text-decoration:none;font-size:0.9rem;">Subscribe Now — $29/mo</a>
       </div>`;
+  }
+}
+
+// Handle returning from Stripe payment success
+function checkPaymentReturn() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('payment') === 'success') {
+    toast('Payment successful! Welcome to Aligned Hearts.');
+    // Clean URL
+    window.history.replaceState({}, '', '/faith-match');
   }
 }
 
@@ -1036,6 +1047,7 @@ async function checkProfile() {
       showScreen('discover-screen');
       loadDiscover();
       loadMyScore();
+      startNotificationPolling();
       // Show assessment reminder if no assessment yet
       if (!d.profile.master_score && !d.profile.time_total) {
         const reminder = document.getElementById('assessment-reminder');
@@ -1087,7 +1099,12 @@ function navTo(btn) {
   btn.classList.add('active');
   const screen = btn.dataset.screen;
   showScreen(screen);
-  if (screen === 'matches-screen') loadMatches();
+  if (screen === 'matches-screen') {
+    loadMatches();
+    // Clear badge when viewing matches
+    const badge = document.getElementById('match-badge');
+    if (badge) badge.classList.add('hidden');
+  }
   if (screen === 'discover-screen') { if (!discoverProfiles.length) loadDiscover(); }
 }
 
@@ -1269,6 +1286,7 @@ async function submitProfile() {
     showScreen('discover-screen');
     loadDiscover();
     loadMyScore();
+    startNotificationPolling();
   } catch (e) { toast('Error saving profile'); }
 }
 
@@ -1632,6 +1650,34 @@ async function loadMyScore() {
   } catch {}
 }
 
+// ===== NOTIFICATION POLLING =====
+let notifInterval = null;
+
+async function pollNotifications() {
+  if (!token) return;
+  try {
+    const r = await fetch(API + '/dating/unread', { headers: authHeaders() });
+    const d = await r.json();
+    // Update matches badge
+    const badge = document.getElementById('match-badge');
+    if (badge) {
+      const total = (d.unreadMessages || 0) + (d.newMatches || 0);
+      if (total > 0) {
+        badge.textContent = total > 9 ? '9+' : total;
+        badge.classList.remove('hidden');
+      } else {
+        badge.classList.add('hidden');
+      }
+    }
+  } catch {}
+}
+
+function startNotificationPolling() {
+  if (notifInterval) clearInterval(notifInterval);
+  pollNotifications(); // immediate first check
+  notifInterval = setInterval(pollNotifications, 15000); // every 15s
+}
+
 async function toggleActive(active) {
   try {
     await fetch(API + '/dating/toggle-active', {
@@ -1669,6 +1715,9 @@ function escapeHtml(str) {
 window.addEventListener('DOMContentLoaded', () => {
   const savedEmail = localStorage.getItem('ve_email');
   if (savedEmail) document.getElementById('login-email').value = savedEmail;
+
+  // Handle returning from Stripe payment
+  checkPaymentReturn();
 
   // Handle PIN reset link from email
   const urlParams = new URLSearchParams(window.location.search);

--- a/vercel.json
+++ b/vercel.json
@@ -303,6 +303,10 @@
       "dest": "/agent-dashboard.html"
     },
     {
+      "src": "/dating-admin",
+      "dest": "/dating-admin.html"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
     }


### PR DESCRIPTION
Stripe Payment Gates (checkout.js):
- Add $0.97 one-time payment for assessment gate (dating-gate tier)
- Add $29/mo subscription for trial-expired users (dating-monthly tier)
- Support both one-time (mode: payment) and subscription (mode: subscription)
- Webhook syncs dating_profiles.is_paid and restores trial on gate payment
- Frontend buttons in faith-match.html now link to real Stripe checkout

Photo CDN Upload (dating.js):
- Upload photos to Cloudinary when CLOUDINARY_CLOUD_NAME and CLOUDINARY_UPLOAD_PRESET env vars are set
- Falls back to base64 storage if Cloudinary not configured
- Auto-resizes to 800x1000, quality auto, format auto
- Increased size limit from 2MB to 5MB

Admin Moderation Panel (dating-admin.html):
- Login with admin API key
- Dashboard: total profiles, active, matches, messages, reports, paid/trial
- Reports tab: view pending reports, dismiss/warn/suspend/ban actions
- Profiles tab: full table of all dating profiles with stats
- Route: /dating-admin

API Endpoints Added:
- GET /api/dating/unread — unread message count + new match count (badges)
- GET /api/dating/admin/reports — list reports by status
- POST /api/dating/admin/report-action — dismiss/warn/suspend/ban
- GET /api/dating/admin/profiles — all profiles with stats
- GET /api/dating/admin/stats — aggregate dating platform stats

Notification System (faith-match.html):
- Polls /api/dating/unread every 15 seconds
- Shows red badge on matches tab with unread count
- Badge clears when user views matches screen
- Starts polling after login/profile creation

https://claude.ai/code/session_01UbwXpTdZEoZt4wHzw2wnts