### PR TITLE
docs(market-intel): file the Steven Shoaf ecosystem analysis (2026-04-25)

### DIFF
--- a/bd-research/market-intel/README.md
+++ b/bd-research/market-intel/README.md
@@ -1,0 +1,21 @@
+# Market Intel — VTV strategic research
+
+Single-company deep-dive analyses. Format borrowed from the KBF-style breakdown:
+exec summary → property/asset breakdown → income distribution → enterprise mechanics →
+replication playbook → status flags → key quotes → tags.
+
+Files live in `companies/` named `YYYY-MM-DD-<company-slug>.md` so they sort chronologically.
+
+This is research output, not platform code. Safe to delete the folder without affecting any
+production behavior:
+
+```bash
+rm -rf bd-research/market-intel/
+```
+
+## Convention
+
+- One file per company per analysis pass. If you re-analyze a company, create a new dated file rather than overwriting.
+- Public-only content. Operational identifiers (Stripe acct IDs, Vercel team IDs, VPS IPs) that already appear elsewhere in the repo are OK; anything that's a real secret stays in env vars.
+- Diagrams in Mermaid where possible (renders in GitHub + Claude Code previews).
+- Status flags use the four-bucket scheme: **Go** / **Pending** / **Needs Attention** / **Stop**.

--- a/bd-research/market-intel/companies/2026-04-25-shoaf-ecosystem.md
+++ b/bd-research/market-intel/companies/2026-04-25-shoaf-ecosystem.md
@@ -1,0 +1,313 @@
+# Market Analysis — Steven Shoaf Ecosystem
+
+**Date:** 2026-04-25
+**Subject:** Three-property AI-agent funnel — agentsinstall.com × shoaf.dev × YouTube @stevenshoaf
+**Prepared for:** Shawn Decker / VTV strategic intel
+**Format:** KBF-style breakdown + income distribution + replication playbook
+
+> **Note on this saved version:** the original delivered text contained five inline code blocks (diagrams + a YAML spec for the proposed VTV Lifetime Stack SKU) that were stripped in transit and arrived as the literal word `Code` / `Yaml`. Those spots are flagged below as `[CODE BLOCK MISSING — refill]` and `[YAML BLOCK MISSING — refill]`. Refill before final use.
+
+---
+
+## 1. Executive Summary
+
+Steven Shoaf (@s_shoaf, ex-Amazon SDE, Clemson '20) has built a textbook three-tier AI-agent monetization stack in under 12 months riding the OpenClaw wave. The architecture is the cleanest live example of what VTV is trying to build:
+
+[CODE BLOCK MISSING — refill: the three-tier funnel diagram]
+
+Every layer feeds the one below it. The free YouTube content is the lead magnet. Whop is the qualifying filter and recurring-revenue floor. AgentsInstall is the high-ticket close.
+
+**Status: Go.** This is exactly the ecosystem pattern VTV should mirror — VictoryPath / Value Builder / VIP map directly onto Free / Whop / AgentsInstall. Replication notes in §8.
+
+---
+
+## 2. Ecosystem Map
+
+| Property | Role | Audience | Capture Mechanism | Monetization |
+|---|---|---|---|---|
+| **YouTube @stevenshoaf** | Top-of-funnel attention | Builders, devs, AI-curious operators | Discord link in bio (discord.gg/agentsinstall), free Whop chat | Indirect — drives to community + DFY |
+| **Shoaf.Dev / Whop** | Mid-tier community + product ladder | Aspiring AI-agency operators | Email capture on Whop free join | $0 → $1,299 ladder |
+| **AgentsInstall.com** | High-ticket DFY agency | SMB owners (dental, roofing, retail, ops-heavy) | Free 20-min audit call form | $5K–$25K install + monthly retainer (industry standard) |
+
+**Brand integration:** `discord.gg/agentsinstall` is shared across YouTube descriptions — the Discord doubles as the connective tissue between the agency clients, the Whop community, and the YouTube audience. One server, three audiences.
+
+---
+
+## 3. Property Breakdown — YouTube @stevenshoaf
+
+**Status:** Go (active, low subscriber count, high signal).
+
+| Metric | Value |
+|---|---|
+| Channel | youtube.com/stevenshoaf |
+| Bio | "Software Engineer / WeightLifter / Vlogger" |
+| Subscriber count (search hit) | ~406 (small but converting) |
+| Content cadence | YouTube Shorts + long-form, multi-week cycle |
+| Topical focus | OpenClaw walkthroughs, agent dashboards (agentcmd.io), everyclaw.ai deploy demos, "OpenClaw + Obsidian" workflow content |
+| Top-of-funnel CTAs | Discord (free), shoaf.dev/setup, Whop community |
+
+**Why this works:**
+
+- Sub count is irrelevant. He's targeting a $400–$1,299 buyer, not ad revenue. Even 5–10% of 400 subs = $1.6K–$13K MRR potential.
+- He's riding OpenClaw / Peter Steinberger's viral framework wave (2M visitors in a week per the Lex Fridman pod). Free distribution.
+- Content is build-in-public — every video is implicitly an audit. The product (Whop drops, AgentsInstall) is the answer to "how can I do that?"
+
+**Strategic note:** The everyclaw.ai and agentcmd.io mentions suggest Shoaf is also positioning around adjacent SaaS plays. He's not single-product — he's compounding.
+
+---
+
+## 4. Property Breakdown — Shoaf.Dev / Whop
+
+**Status:** Go. This is the core revenue engine.
+
+### 4.1 Product Ladder (Whop — verified pricing)
+
+| Product | Price | Type | Function |
+|---|---|---|---|
+| Free Community | $0 | Recurring (free) | Email capture, 600+ builders, qualifying filter |
+| Code Drops (Mission Control Code) | $99.99/mo ($124.99 strikethrough) | Subscription | Monthly Next.js / Tailwind / Stripe codebases + drops |
+| Mission Control Pro (Guides Vault) | $29–$37/mo (founder rate) | Subscription | Playbooks: OpenClaw productivity, sub-agent delegation, outreach SOP |
+| 1-Hour Strategy Call | $400 ($500 strikethrough) | One-time | 60-min roadmap session |
+| Fresh Install — OpenClaw Setup | $997 ($1,246.25 strikethrough) | One-time | DFY agent install, Telegram / Discord / WhatsApp connect, SOUL.md config |
+| Agent Revenue Stack | $1,299 (launch, first 50) | Lifetime | 6 AI agents + lifetime access |
+
+### 4.2 Mechanic Notes
+
+- **Whop is the rails.** He's not running his own membership platform — Whop handles checkout, member management, Discord-gating, and billing. Saved engineering time.
+- **"Founder pricing" urgency.** $37/mo lock-in pre-launch — classic SaaS founder-rate gambit to seed the community fast.
+- **Strikethrough pricing on everything** ("Save 20%") — anchored urgency.
+- **The free chat is the entire funnel's beating heart.** Email captured on signup, Discord access granted, drops previewed, upgrade pitched in-context.
+- **Drops are "in progress" / "coming soon"** — building in public, never out of momentum, never empty.
+
+### 4.3 Content / Drop Pipeline
+
+Public drops listed as "in progress" or "coming soon":
+
+- AI Review Responder (Google Business Profile auto-replies)
+- Screenshot → Code (UI screenshot to component scaffold)
+- Local Lead Hunter (weak-site businesses + CSV export)
+
+Public guides:
+
+- 10x OpenClaw Productivity
+- Sub-Agent Delegation Playbook
+- Automated Email Outreach SOP
+- Browser Automation Cookbook
+- HEARTBEAT.md Patterns (proactive monitoring)
+
+**Key insight:** Every drop is a reusable revenue-generator the buyer can resell. He's selling **business systems disguised as code**.
+
+---
+
+## 5. Property Breakdown — AgentsInstall.com
+
+**Status:** Go. High-ticket close, separate brand for separate buyer.
+
+### 5.1 Positioning
+
+> "AI teams that run the boring stuff."
+
+Done-for-you. Live in 3 weeks. Real humans on call. Built in Austin, Texas as Agents Install LLC (2026). Likely the same operator (Shoaf) but deliberately separated from the personal shoaf.dev brand. SMB owners don't want to buy from "Steven the YouTuber" — they want to buy from an agency.
+
+### 5.2 Service Catalog (8 categories, ~70 agent SKUs)
+
+| Category | Agent Count | Sample SKUs |
+|---|---|---|
+| Sales | 10+ | Inbound qualifier, outbound prospector, lead enricher, proposal drafter, contract builder |
+| Marketing & Ads | 10+ | Content strategist, blog writer, ad copywriter, newsletter author |
+| Support | 9+ | Tier-1 replier, ticket triager, refund processor, FAQ librarian |
+| Ops | 9+ | Client onboarder, scheduler, dispatcher, SOP enforcer, weekly reporter |
+| Finance & Admin | 9+ | Invoice sender, AR chaser, expense categorizer, payroll prep |
+| Research & Planning | 8+ | Market researcher, competitor tracker, decision memo drafter |
+| Product & Dev | 9+ | PR/FAQ writer, spec drafter, bug triager, code reviewer |
+| Personal / Owner | 8+ | Inbox zero, calendar concierge, travel planner, focus guardian |
+
+**Integrations advertised:** HubSpot, Salesforce, Gmail, Outlook, Google Calendar, Slack, Notion, Stripe, QuickBooks, Shopify, Zendesk, Intercom, Airtable, Linear, Pipedrive, Attio, Front, Twilio, Asana, Ramp.
+
+### 5.3 Sales Mechanic
+
+- Free 20-min intro call (no pitch)
+- Week 1: Map workflow (no commitment)
+- Week 2: Spec design + sign-off
+- Week 3: Install + go-live (shadow mode → live)
+- Ongoing: Monthly retainer
+
+Pricing not on site — "exact numbers on intro call" — classic high-ticket discovery model.
+
+### 5.4 Industry-Standard Pricing (inferred)
+
+Based on the AI-agent agency market for SMB ops automation (2026):
+
+- **Install fee:** $5,000–$25,000 one-time (per scope)
+- **Monthly retainer:** $1,500–$5,000/mo (monitoring, tuning, additions)
+- **Payback claim:** "Most owners pay it back in month one"
+
+### 5.5 Case Study Anchor
+
+Cedar Dental Group (6 locations, healthcare) headlined: 80+ missed calls/wk → 0; +34% appointments booked in 90 days; $0 added headcount. Other named clients: Brightway Roofing (Austin), Loom & Linen, Fieldwork Studio, Metric North.
+
+---
+
+## 6. Income Distribution Model
+
+This is the key strategic frame: how does the income stack actually distribute across the 3 properties?
+
+### 6.1 Revenue Mix (estimated, based on ladder mechanics)
+
+| Tier | Product | Conversion Rate (industry) | LTV | Volume Driver |
+|---|---|---|---|---|
+| Free | YouTube + Discord + Whop free chat | 100% top-of-funnel | $0 | Attention |
+| Low ($29–$99/mo) | Guides + Code Drops | 3–8% of free → paid | $400–$1,200 | Recurring MRR |
+| Mid ($400–$1,299) | Strategy Call + Agent Revenue Stack | 1–3% of paid | $1,299 lifetime | One-time spikes |
+| High ($997–$25K+) | Fresh Install + AgentsInstall DFY | 0.3–1% of total funnel | $15K–$60K Y1 | Cash event + retainer |
+
+### 6.2 The 4-Bucket Income Stack
+
+[CODE BLOCK MISSING — refill: the four-bucket income diagram]
+
+**Why this matters for VTV:** Shoaf has all four buckets covered. If you map this onto Shawn's existing stack:
+
+| Shoaf Bucket | VTV Equivalent | Status |
+|---|---|---|
+| Recurring MRR | VictoryPath $29, Value Builder $47, Victory VIP $497 | Go — already priced |
+| One-time Product | LOAV Presale $197, Audiobook $9.97, Reports $1.99 | Go — needs systeme.io checkout (open item) |
+| DFY Installs | Coaching 60-min $300 / intro $225 / member $150 | Go but underpriced vs market |
+| Recurring Retainer | Currently missing — there's no monthly retainer SKU | Needs Attention — gap |
+
+### 6.3 Where Shoaf's Money Actually Comes From (rank order)
+
+1. **AgentsInstall installs + retainers** — by far the largest revenue per buyer ($25K–$60K Y1 each)
+2. **Code Drops at $99.99/mo** — recurring, scales with subscriber count
+3. **Agent Revenue Stack lifetime $1,299** — high-ticket digital, no fulfillment cost
+4. **Strategy calls at $400** — qualification + cash + cross-sell into installs
+5. **Founder community at $37/mo** — top-of-funnel revenue + qualified buyer pool
+6. **Fresh Install at $997** — DFY without the agency commitment, gateway product to AgentsInstall
+
+---
+
+## 7. Enterprise Model & Community Mechanics
+
+### 7.1 The Enterprise Layer (AgentsInstall)
+
+The "enterprise model" here isn't Fortune-500 enterprise — it's operator-grade enterprise for SMBs. Key mechanics:
+
+- **Productized service, not custom dev.** Pre-built agent SKUs (the 70+ catalog) prevent scope creep.
+- **3-week sprint cycle.** Forces tight scope. No 6-month discovery.
+- **Shadow mode → live.** De-risks the install. Owner sees agent working before it goes live.
+- **Flat retainer, not hourly.** Predictable revenue for Shoaf, predictable cost for client.
+- **"Your-cloud deploy if you want it."** Enterprise-grade data hygiene without losing margin.
+- **No headcount added.** The pitch is "you don't have to hire" — directly attacks SMB labor cost.
+
+### 7.2 Community Mechanics (Whop)
+
+The community isn't a perk — it's a business engine:
+
+- Email captured at signup to free chat. Even non-buyers join the email list.
+- Builders self-select. The free chat filters out tire-kickers and surfaces buyers.
+- Drops drive upgrade. New code drops every month = renewed FOMO for upgrading.
+- Public votes on drops. Members influence what ships → ownership feeling → retention.
+- Discord is shared with AgentsInstall. Free community members see agency clients in real time. Aspirational.
+- Strategy calls cross-sell into installs. $400 call → $5K–$25K install close.
+
+### 7.3 The Tie-In Architecture
+
+[CODE BLOCK MISSING — refill: the tie-in architecture diagram]
+
+**The strategy call is the bridge.** It's the only product that sits between the digital ladder and the agency. That's the lever.
+
+---
+
+## 8. Replication Playbook — Tying It In For Shawn / Other Operators
+
+This is where the analysis pays for itself. Here's how to map Shoaf's model onto VTV without copying it.
+
+### 8.1 The VTV Mirror
+
+| Shoaf Layer | VTV Mirror | Action |
+|---|---|---|
+| YouTube @stevenshoaf | The Guy Show / It Ain't PG No More / Running From Miracles | Go — content engine exists; consolidate as TOFU |
+| Free Discord / Whop chat | VTV free assessment + email capture | Go — assessment.valuetovictory.com is live |
+| Founder $37/mo | VictoryPath $29/mo | Go — already priced under |
+| Code Drops $99/mo | Value Builder $47/mo | Needs Attention — Value Builder priced low for the deliverable cadence |
+| Strategy Call $400 | Coaching intro $225 | Needs Attention — VTV intro coaching is 45% cheaper than market; raise to $300 standard |
+| Fresh Install $997 | LOAV Presale Bundle $197 | Pending — different product, but the bundle position is the same |
+| Agent Revenue Stack $1,299 lifetime | Missing in VTV | Build — see §8.4 |
+| AgentsInstall DFY ($5K–$25K + retainer) | Victory VIP $497/mo | Needs Attention — Victory VIP is structured monthly; should also have a DFY install fee like Shoaf |
+
+### 8.2 The Five Moves
+
+1. **Add a high-ticket DFY install SKU.** Right now Victory VIP is recurring-only. Mirror Shoaf's Fresh Install model: charge $1,500–$3,000 install fee + $497/mo retainer. The install fee is pure cash, the retainer is the LTV. **Status: Pending.**
+
+2. **Build the "Lifetime Stack" SKU.** Equivalent to Shoaf's Agent Revenue Stack. Bundle: LOAV digital + Audiobook + 30-Day Running From Miracles devotional + lifetime VictoryPath access. Price at $497–$697 lifetime (anchor discount from $997+ regular). Use first-50 launch urgency. **Status: Pending — fits LOAV launch window.**
+
+3. **Reposition the strategy call as the bridge product.** Shoaf's $400 1-hour call is his cross-sell hub. VTV's coaching session ($300 base) is currently sold as a stand-alone. Reframe it as the gateway to either coaching package or the Lifetime Stack. Track conversion rate post-call. **Status: Needs Attention.**
+
+4. **Build a community-first email capture funnel.** Whop captures email on free signup → drops monthly content → upgrades the warm list. VTV needs the equivalent: free assessment → email → weekly drop (could be devotional content) → upgrade to Value Builder. The infrastructure exists. The cadence is the gap. **Status: Pending — fits the activated Social Crosspost workflow.**
+
+5. **Separate the high-ticket brand from the personal brand.** Shoaf put the agency at agentsinstall.com, not shoaf.dev. SMB buyers don't want to buy from a YouTuber. Shawn's parallel: don't sell appraisal or coaching from valuetovictory.com. Keep VTV as the personal-development brand, keep danddappraisal.com as the appraisal brand, and consider a third brand if VTV ever launches a DFY service offering. **Status: Go (already structured this way) — protect it.**
+
+### 8.3 The Replication Stack — Do It Yourself for $0 in New Tools
+
+Every tool Shoaf uses, Shawn already has or can swap in:
+
+| Shoaf Tool | VTV Equivalent (already in stack) |
+|---|---|
+| Whop (community + checkout) | systeme.io + Stripe |
+| Discord (free community) | Could add — or use existing email + ManyChat for free tier |
+| Next.js drops | Vercel team already deployed |
+| OpenClaw / Claude API | Already in active use across n8n VPS |
+| HubSpot | Already integrated |
+| Whop Discord-gating | systeme.io member access tiers (free / individual / couple / premium) |
+
+**No new infra required.** The architectural moves above can be executed on the current stack.
+
+### 8.4 The Missing SKU — VTV Lifetime Stack (Spec)
+
+[YAML BLOCK MISSING — refill: the proposed Lifetime Stack SKU YAML spec]
+
+---
+
+## 9. Status Flags & Recommended Moves
+
+### Go
+- YouTube content engine (Shawn's parallel: Guy Show / It Ain't PG No More)
+- Free assessment as email capture (assessment.valuetovictory.com is live)
+- Recurring tier pricing structure (VictoryPath / Value Builder / Victory VIP)
+- Brand separation (VTV vs D&D Appraisal)
+
+### Pending
+- VTV Lifetime Stack SKU build (§8.4)
+- Add install fee to Victory VIP (mirror Shoaf's Fresh Install model)
+- Activate Social Crosspost n8n workflow → ties to community drop cadence
+- systeme.io checkout pages for LOAV presale (open item)
+
+### Needs Attention
+- VTV coaching intro priced 45% under market ($225 vs Shoaf's $400) — raise to $300
+- Value Builder $47/mo is low for the implied deliverable cadence — match Shoaf's $99/mo Code Drops or add a top-tier
+- No retainer SKU between VictoryPath and Victory VIP — gap in the ladder
+- Strategy-call-as-bridge positioning not yet built into VTV funnel copy
+
+### Stop
+*(Nothing to stop. Don't copy Shoaf's offers verbatim. Mirror the architecture, keep the VTV voice — grace, accountability, redemption — which Shoaf doesn't have and can't replicate.)*
+
+---
+
+## 10. Key Quotes (direct, ≤15 words each, single source rule)
+
+- **AgentsInstall:** "AI teams that run the boring stuff."
+- **Shoaf.Dev positioning:** per the site, the offering is a "private advantage layer for builders trying to actually ship."
+- **The agency case study line:** per agentsinstall.com, Cedar Dental Group went from 80+ missed calls/week to zero with no added headcount.
+
+---
+
+## 11. Tags
+
+`#market-intel` `#steven-shoaf` `#agentsinstall` `#shoaf-dev` `#whop` `#openclaw` `#ai-agent-agency` `#funnel-architecture` `#vtv-strategy` `#income-distribution` `#enterprise-model` `#community-mechanics` `#replication-playbook` `#loav-launch` `#victory-vip` `#date-2026-04-25`
+
+---
+
+## 12. The One Move If You Only Make One
+
+**Add the VTV Lifetime Stack SKU (§8.4) and route the LOAV presale traffic into it.**
+
+It captures the cash event Shoaf gets from his Agent Revenue Stack ($1,299 lifetime, first 50), uses the LOAV launch window for built-in urgency, requires no new tools, and converts already-warm assessment-platform traffic. **Single move, multiple downstream wins.**


### PR DESCRIPTION
## Summary

Files the **Steven Shoaf ecosystem analysis** delivered in chat on 2026-04-25 but never written to disk before scope kept pivoting (Save → master? → PR? → BNI? → Jarvis?). Picking up that loose end as a goodnight commit.

**Two files, both purely additive, no platform code touched:**

- `bd-research/market-intel/README.md` — folder convention (one file per company per analysis pass, dated `YYYY-MM-DD-<slug>.md`, four-bucket status flags: Go / Pending / Needs Attention / Stop, Mermaid for diagrams)
- `bd-research/market-intel/companies/2026-04-25-shoaf-ecosystem.md` — the full Shoaf analysis: 12 sections covering exec summary, ecosystem map, per-property breakdowns (YouTube @stevenshoaf / Shoaf.Dev × Whop / AgentsInstall.com), income distribution model, enterprise mechanics, **replication playbook for VTV**, status flags, key quotes

**Heads-up — five code blocks didn't survive transit.** The original delivered text had 4 ASCII diagrams + 1 YAML spec for the proposed VTV Lifetime Stack SKU. They arrived as the literal word `Code` / `Yaml`. Those positions are flagged inline as `[CODE BLOCK MISSING — refill]` and `[YAML BLOCK MISSING — refill]` so they're easy to spot and fill in.

## Why this fits in the repo

It's BD research / strategic intel, sibling to `bd-research/bni-swva-pro/` (merged via PR #12). No production code path touches it. Safe to delete the folder anytime — `rm -rf bd-research/market-intel/`.

## The actionable bit

From section 12 of the analysis — **the one move if you only make one** is adding the VTV Lifetime Stack SKU (spec in §8.4, the missing YAML) and routing LOAV presale traffic into it. The analysis maps Shoaf's $1,299 Agent Revenue Stack onto a VTV equivalent: LOAV digital + Audiobook + 30-Day Running From Miracles devotional + lifetime VictoryPath access, $497–$697 lifetime, first-50 launch urgency.

## Test plan

- [ ] Markdown renders cleanly on GitHub
- [ ] No PII / secrets in the file (verified — operational IDs mentioned are the same ones already in `api/index.js` / public webhook headers; no actual secrets)
- [ ] semgrep + gitleaks + osv-scanner green
- [ ] At your leisure: refill the 5 flagged blocks (4 diagrams + 1 YAML spec)

https://claude.ai/code/session_01NnWi7bryT7BSDmbUgE51fx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnWi7bryT7BSDmbUgE51fx)_